### PR TITLE
test(*): added Main Repository Spek

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ This project uses
  - Data Binding
  - RxBinding
  - Leak Canary
- - Architecture Components (Future)
+ - Architecture Components? Nullable :P
+ - Spek Framework for testing
 
 ### Krazzy Kool Kotlin Kid
 
@@ -48,8 +49,8 @@ Coming Soon!!
 ### To-do
  - More Features
  - Architecture Components?
- - Testing
- - Documentation
+ - Improve Testing
+ - Improve Documentation
 
 ### Contributing
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -20,6 +21,7 @@ allprojects {
         google()
         jcenter()
         maven { url "https://jitpack.io" }
+        maven { url "http://dl.bintray.com/jetbrains/spek" }
     }
     ext {
         retrofitVersion = '2.3.0'
@@ -28,7 +30,6 @@ allprojects {
         constraint_layout = '1.1.0-beta3'
         arch_comp       = '1.0.0'
         arch_comp_paging= '1.0.0-alpha3'
-        kotlin          = '1.2.0'
         espresso        = '3.0.1'
         dagger          = '2.12'
         ktlint          = '0.10.0'
@@ -42,6 +43,12 @@ allprojects {
         databinding     = '3.0.0'
         reclaim         = '1.1.1'
         rxBindings      = '2.0.0'
+
+        // test libraries
+        kluent = '1.4'
+        spek = '1.1.5'
+        mockitoKotlin = '1.5.0'
+        mockito = '2.8.9'
     }
 }
 

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     kapt "com.google.dagger:dagger-compiler:$dagger"
     kapt "com.google.dagger:dagger-android-processor:$dagger"
 
-    testCompile ("org.amshove.kluent:kluent:$kluent")
+    testCompile "org.amshove.kluent:kluent:$kluent"
     testImplementation "org.jetbrains.spek:spek-api:$spek"
     testImplementation "org.jetbrains.spek:spek-junit-platform-engine:$spek"
     testCompile "com.nhaarman:mockito-kotlin-kt1.1:$mockitoKotlin"

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -1,5 +1,15 @@
 apply plugin: 'kotlin'
 apply plugin: 'kotlin-kapt'
+apply plugin: 'org.junit.platform.gradle.plugin'
+
+
+junitPlatform {
+    filters {
+        engines {
+            include 'spek'
+        }
+    }
+}
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
@@ -17,5 +27,10 @@ dependencies {
     kapt "com.google.dagger:dagger-compiler:$dagger"
     kapt "com.google.dagger:dagger-android-processor:$dagger"
 
-    testImplementation "junit:junit:$junit"
+    testCompile ("org.amshove.kluent:kluent:$kluent")
+    testImplementation "org.jetbrains.spek:spek-api:$spek"
+    testImplementation "org.jetbrains.spek:spek-junit-platform-engine:$spek"
+    testCompile "com.nhaarman:mockito-kotlin-kt1.1:$mockitoKotlin"
+    testImplementation "org.mockito:mockito-core:$mockito"
+
 }

--- a/data/src/main/java/com/ragdroid/data/MainRepositoryImpl.kt
+++ b/data/src/main/java/com/ragdroid/data/MainRepositoryImpl.kt
@@ -17,10 +17,10 @@ import javax.inject.Inject
 class MainRepositoryImpl
     @Inject
     constructor(
-            val marvelApi: MarvelApi,
-            val characterMapper: CharacterMapper,
-            val config: AppConfig,
-            val helpers: Helpers): MainRepository {
+            private val marvelApi: MarvelApi,
+            private val characterMapper: CharacterMapper,
+            private val config: AppConfig,
+            private val helpers: Helpers): MainRepository {
 
 
     override fun fetchCharacters(): Single<List<CharacterMarvel>> {
@@ -45,7 +45,7 @@ class MainRepositoryImpl
                 timeStamp,
                 0,
                 10,
-                null
+                ""
         )
     }
 

--- a/data/src/test/java/com/ragdroid/data/MainRepositorySpec.kt
+++ b/data/src/test/java/com/ragdroid/data/MainRepositorySpec.kt
@@ -33,16 +33,16 @@ object MainRepositorySpec: Spek({
             config = mock(AppConfig::class)
             helpers = mock(Helpers::class)
 
-            `when`(config.publicKey).thenReturn("publicKEY")
-            `when`(config.privateKey).thenReturn("privateKey")
-            `when`(mapper.map(any())).thenReturn(getFakeMarvelCharacterData())
-            `when`(helpers.buildMD5Digest(anyString())).thenReturn("Digest")
+            whenever(config.publicKey).thenReturn("publicKEY")
+            whenever(config.privateKey).thenReturn("privateKey")
+            whenever(mapper.map(any())).thenReturn(getFakeMarvelCharacterData())
+            whenever(helpers.buildMD5Digest(anyString())).thenReturn("Digest")
 
             repository = MainRepositoryImpl(mockApi, mapper, config, helpers)
         }
 
         on("fetching from repository") {
-            `when`(mockApi.getCharacters(anyString(), anyString(), anyLong(), anyInt(), anyInt(), any()))
+            whenever(mockApi.getCharacters(anyString(), anyString(), anyLong(), anyInt(), anyInt(), any()))
                     .thenReturn(Single.just(getFakeMarvelCharacters()))
             val testObserver = TestObserver<List<CharacterMarvel>>()
             repository.fetchCharacters()
@@ -62,7 +62,7 @@ object MainRepositorySpec: Spek({
 
         on("fetching from repository gives error") {
             val error = mock(Throwable::class)
-            `when`(mockApi.getCharacters(anyString(), anyString(), anyLong(), anyInt(), anyInt(), any()))
+            whenever(mockApi.getCharacters(anyString(), anyString(), anyLong(), anyInt(), anyInt(), any()))
                     .thenReturn(Single.error(error))
             val testObserver = TestObserver<List<CharacterMarvel>>()
             repository.fetchCharacters()

--- a/data/src/test/java/com/ragdroid/data/MainRepositorySpec.kt
+++ b/data/src/test/java/com/ragdroid/data/MainRepositorySpec.kt
@@ -1,0 +1,83 @@
+package com.ragdroid.data
+
+import com.ragdroid.api.MarvelApi
+import com.ragdroid.data.base.Helpers
+import com.ragdroid.data.entity.AppConfig
+import com.ragdroid.data.entity.CharacterMapper
+import com.ragdroid.data.entity.CharacterMarvel
+import io.reactivex.Single
+import io.reactivex.observers.TestObserver
+import org.amshove.kluent.mock
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import org.jetbrains.spek.api.dsl.xit
+import org.mockito.Mockito.*
+
+/**
+ * Created by garimajain on 09/12/17.
+ */
+
+object MainRepositorySpec: Spek({
+    given("a repository") {
+        var mockApi = mock(MarvelApi::class)
+        var mapper = mock(CharacterMapper::class)
+        var config = mock(AppConfig::class)
+        var helpers = mock(Helpers::class)
+        var repository = MainRepositoryImpl(mockApi, mapper, config, helpers)
+
+        beforeEachTest {
+            mockApi = mock(MarvelApi::class)
+            mapper = mock(CharacterMapper::class)
+            config = mock(AppConfig::class)
+            helpers = mock(Helpers::class)
+
+            `when`(config.publicKey).thenReturn("publicKEY")
+            `when`(config.privateKey).thenReturn("privateKey")
+            `when`(mapper.map(any())).thenReturn(getFakeMarvelCharacterData())
+            `when`(helpers.buildMD5Digest(anyString())).thenReturn("Digest")
+
+            repository = MainRepositoryImpl(mockApi, mapper, config, helpers)
+        }
+
+        on("fetching from repository") {
+            `when`(mockApi.getCharacters(anyString(), anyString(), anyLong(), anyInt(), anyInt(), any()))
+                    .thenReturn(Single.just(getFakeMarvelCharacters()))
+            val testObserver = TestObserver<List<CharacterMarvel>>()
+            repository.fetchCharacters()
+                    .subscribe(testObserver)
+
+            it("should receive 1 value") {
+                testObserver.assertValueCount(1)
+            }
+            it("should not error") {
+                testObserver.assertNoErrors()
+            }
+            it("should complete") {
+                testObserver.assertComplete()
+
+            }
+        }
+
+        on("fetching from repository gives error") {
+            val error = mock(Throwable::class)
+            `when`(mockApi.getCharacters(anyString(), anyString(), anyLong(), anyInt(), anyInt(), any()))
+                    .thenReturn(Single.error(error))
+            val testObserver = TestObserver<List<CharacterMarvel>>()
+            repository.fetchCharacters()
+                    .subscribe(testObserver)
+            it("should error") {
+                testObserver.assertError(error)
+            }
+            it("should emit no values") {
+                testObserver.assertValueCount(0)
+            }
+            xit("should complete") {
+                //TODO It doesn't show proper error message, ignored, check later
+                testObserver.assertComplete()
+            }
+        }
+    }
+})
+

--- a/data/src/test/java/com/ragdroid/data/TestDataFactory.kt
+++ b/data/src/test/java/com/ragdroid/data/TestDataFactory.kt
@@ -1,0 +1,48 @@
+package com.ragdroid.data
+
+import com.ragdroid.api.entity.*
+import com.ragdroid.data.entity.CharacterMarvel
+
+/**
+ * Created by garimajain on 09/12/17.
+ */
+fun getFakeMarvelCharacters(): TDataWrapper<List<TCharacterMarvel>> {
+    val tDataContainer = TDataContainer(1, 2, 10, 2, listOf(getFakeMarvelCharacter()))
+    return TDataWrapper(
+            1,
+            "sttaus",
+            "copyRIght",
+            "text",
+            "html",
+            "etag",
+            tDataContainer)
+}
+
+
+fun getFakeMarvelCharacter() = TCharacterMarvel(1234,
+        "Name",
+        "I am Marvel Character",
+        getFakeThumbnail(),
+        getFakeCharacterComicWrapper(),
+        getFakeCharacterComicWrapper(),
+        getFakeCharacterComicWrapper(),
+        getFakeCharacterComicWrapper(),
+        emptyList()
+)
+
+
+fun getFakeThumbnail() = TImage("https://abcd.com", "jpg")
+
+fun getFakeCharacterComicWrapper() = TCharacterComicWrapper(
+        10,
+        "https://collections.com/abcd",
+        5,
+        emptyList()
+)
+
+fun getFakeMarvelCharacterData() = CharacterMarvel(
+        1234,
+        "name",
+        "description",
+        "https://abcd.com/image"
+)

--- a/data/src/test/java/com/ragdroid/data/TestHelpers.kt
+++ b/data/src/test/java/com/ragdroid/data/TestHelpers.kt
@@ -2,6 +2,7 @@ package com.ragdroid.data
 
 import com.nhaarman.mockito_kotlin.createinstance.createInstance
 import org.mockito.Mockito
+import org.mockito.stubbing.OngoingStubbing
 
 /**
  * Created by garimajain on 10/12/17.
@@ -9,3 +10,5 @@ import org.mockito.Mockito
 
 //https://medium.com/@elye.project/befriending-kotlin-and-mockito-1c2e7b0ef791
 inline fun <reified T : Any> any() = Mockito.any(T::class.java) ?: createInstance<T>()
+
+fun <T> whenever(methodcall: T): OngoingStubbing<T> = Mockito.`when`(methodcall)!!

--- a/data/src/test/java/com/ragdroid/data/TestHelpers.kt
+++ b/data/src/test/java/com/ragdroid/data/TestHelpers.kt
@@ -1,0 +1,11 @@
+package com.ragdroid.data
+
+import com.nhaarman.mockito_kotlin.createinstance.createInstance
+import org.mockito.Mockito
+
+/**
+ * Created by garimajain on 10/12/17.
+ */
+
+//https://medium.com/@elye.project/befriending-kotlin-and-mockito-1c2e7b0ef791
+inline fun <reified T : Any> any() = Mockito.any(T::class.java) ?: createInstance<T>()

--- a/data/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
 
Test out Spek Framework for writing tests. Example test [here](https://github.com/ragdroid/klayground/pull/2/files#diff-235fa80a77c4a8a38d00beb15d98c484R22)

Pros
 - Looks Good, Forces `given()`, `on()`, `it()` or `decribe()`, `it()` specification writing.
 - Works fine with `.gradlew`
 - Gives readable error messages, picking up a particular `given()`,`on()`, `it()` statement, 

Example : 

_Spek:com.ragdroid.data.MainRepositorySpec:given a repository:on fetching from repository gives error:it should complete_ for [this](https://github.com/ragdroid/klayground/pull/2/files#diff-235fa80a77c4a8a38d00beb15d98c484R76) test

 
Cons
 - Plugin is still under development.
 - Causes issues with error messages not properly showing up in IDE, will show better error messages when ran from `./gradlew`